### PR TITLE
fix(autodisc-server): raise exceptions to front

### DIFF
--- a/services/base/AutoDiscServer/flask_app/app.py
+++ b/services/base/AutoDiscServer/flask_app/app.py
@@ -8,13 +8,12 @@ from auto_disc.utils.leafutils.leafstructs.registration import (
     get_cls_from_path,
     get_modules,
 )
+from experiments.experiments_handler import ExperimentsHandler
 from flask import Flask, jsonify, make_response, request
 from flask_cors import CORS
-from werkzeug.exceptions import HTTPException
-
-from experiments.experiments_handler import ExperimentsHandler
 from utils import AutoDiscServerConfig, list_profiles
 from utils.DB.expe_db_utils import SavableOutputs
+from werkzeug.exceptions import HTTPException
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(dir_path, "../../../libs/auto_disc"))

--- a/services/base/AutoDiscServer/flask_app/app.py
+++ b/services/base/AutoDiscServer/flask_app/app.py
@@ -8,9 +8,11 @@ from auto_disc.utils.leafutils.leafstructs.registration import (
     get_cls_from_path,
     get_modules,
 )
-from experiments.experiments_handler import ExperimentsHandler
 from flask import Flask, jsonify, make_response, request
 from flask_cors import CORS
+from werkzeug.exceptions import HTTPException
+
+from experiments.experiments_handler import ExperimentsHandler
 from utils import AutoDiscServerConfig, list_profiles
 from utils.DB.expe_db_utils import SavableOutputs
 
@@ -26,6 +28,17 @@ config = AutoDiscServerConfig()
 # Experiments
 experiments_handler = ExperimentsHandler()  # Singleton handling experiments
 experiments_handler.reload_running_remote_experiments()
+
+
+@app.errorhandler(Exception)
+def handle_exception(ex):
+    # pass through HTTP errors
+    if isinstance(ex, HTTPException):
+        return ex
+
+    # handle non-HTTP exceptions only, i.e., backend errors
+    error_message = "Error in autodisc-server : {}".format(ex)
+    return make_response(error_message, 500)
 
 
 @app.route("/experiments", methods=["GET"])


### PR DESCRIPTION
Add a generic error handler which passes Python tracebacks to the
frontend to handle and display in a popup.